### PR TITLE
Add logs and XML viewer for data modules

### DIFF
--- a/frontend/src/components/DataModuleViewer.js
+++ b/frontend/src/components/DataModuleViewer.js
@@ -203,6 +203,16 @@ const DataModuleViewer = ({ dataModule, variant }) => {
                 </div>
               </div>
             )}
+
+            {/* AI Output */}
+            {dataModule.ai_suggestions && Object.keys(dataModule.ai_suggestions).length > 0 && (
+              <div className="bg-gray-800/20 border border-gray-600/50 rounded p-3">
+                <h4 className="text-sm font-medium text-gray-300 mb-2">AI Output:</h4>
+                <pre className="text-xs whitespace-pre-wrap break-words">
+                  {JSON.stringify(dataModule.ai_suggestions, null, 2)}
+                </pre>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/MainWorkspace.js
+++ b/frontend/src/components/MainWorkspace.js
@@ -3,6 +3,7 @@ import { FileText } from 'lucide-react';
 import { useAquila } from '../contexts/AquilaContext';
 import DocumentViewer from './DocumentViewer';
 import DataModuleViewer from './DataModuleViewer';
+import XMLEditor from './XMLEditor';
 
 const MainWorkspace = () => {
   const {
@@ -66,48 +67,18 @@ const MainWorkspace = () => {
         <div className="aquila-panel">
           <div className="aquila-panel-header">
             <h3 className="text-sm font-medium">XML Editor - Verbatim</h3>
-            <div className="flex items-center gap-2">
-              <button className="aquila-button-secondary text-xs px-2 py-1">
-                Validate
-              </button>
-              <button className="aquila-button-secondary text-xs px-2 py-1">
-                Format
-              </button>
-            </div>
           </div>
           <div className="aquila-panel-content">
-            <div className="h-full bg-gray-900 p-4 rounded">
-              <div className="text-green-400 font-mono text-sm">
-                {'<?xml version="1.0" encoding="UTF-8"?>'}<br />
-                {'<dmodule>'}<br />
-                {'  <!-- XML content will appear here -->'}<br />
-                {'</dmodule>'}
-              </div>
-            </div>
+            <XMLEditor content={verbatim?.xml_content || ''} readOnly={true} />
           </div>
         </div>
 
         <div className="aquila-panel">
           <div className="aquila-panel-header">
             <h3 className="text-sm font-medium">XML Editor - STE</h3>
-            <div className="flex items-center gap-2">
-              <button className="aquila-button-secondary text-xs px-2 py-1">
-                Validate
-              </button>
-              <button className="aquila-button-secondary text-xs px-2 py-1">
-                Format
-              </button>
-            </div>
           </div>
           <div className="aquila-panel-content">
-            <div className="h-full bg-gray-900 p-4 rounded">
-              <div className="text-green-400 font-mono text-sm">
-                {'<?xml version="1.0" encoding="UTF-8"?>'}<br />
-                {'<dmodule>'}<br />
-                {'  <!-- STE XML content will appear here -->'}<br />
-                {'</dmodule>'}
-              </div>
-            </div>
+            <XMLEditor content={ste?.xml_content || ''} readOnly={true} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add detailed AI processing logs in `DocumentService`
- include AI model responses and rendered XML in returned data modules
- show AI output and logs in `DataModuleViewer`
- display XML for selected modules using `XMLEditor` in `MainWorkspace`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6874b8433afc8329b7e2f05d88458746