### PR TITLE
Add websocket server with SQLite

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -2,14 +2,14 @@
 **Version 1.0.0 (July 2025)**
 
 
-This manual provides step-by-step instructions for using every major feature of the Aquila S1000D-AI prototype. The system consists of a FastAPI backend and a React-based web interface that together help you ingest documents, generate S1000D data modules, and publish technical manuals.
+This manual provides step-by-step instructions for using every major feature of the Aquila S1000D-AI prototype. The system consists of a FastAPI backend with either the original React interface or a lightweight HTML/JS page that together help you ingest documents, generate S1000D data modules, and publish technical manuals.
 
 ## 1. Installation & Setup
 1. Install Python dependencies:
    ```bash
    pip install -r backend/requirements.txt
    ```
-2. Install the frontend packages:
+2. (Optional) install the original React frontend:
    ```bash
    cd frontend
    yarn install
@@ -18,21 +18,14 @@ This manual provides step-by-step instructions for using every major feature of 
 3. Copy `.env.example` in both `backend/` and `frontend/` to `.env` and supply API keys and model names. The system works with OpenAI, Anthropic, or local Hugging Face models.
 4. If you change values in `frontend/.env` while `yarn start` is running, restart the command (or use `npm start`) so the updated variables load.
 5. Start the services in separate terminals:
+   # Alternatively open simple_frontend/index.html for a lightweight interface
    ```bash
-   uvicorn backend.server:app --reload --port 8001
-   cd frontend && yarn start
+   uvicorn backend.websocket_server:app --reload --port 8001
+   open simple_frontend/index.html in your browser
    ```
-   The UI opens at `http://localhost:3000` and connects to the backend on port `8001`.
+   Open the HTML file directly and it will connect to the WebSocket server on port `8001`.
 
-## 2. Authentication
-Most API routes require a user account. Register and obtain a token:
-```bash
-curl -X POST -F "username=test" -F "password=secret" http://localhost:8001/auth/register
-curl -X POST -F "username=test" -F "password=secret" http://localhost:8001/auth/token
-```
-Include the returned token in the `Authorization` header for API calls.
-
-## 3. Configuring AI Providers
+## 2. Configuring AI Providers
 Open the **Provider** modal in the toolbar or call `/api/providers/set` to choose OpenAI, Anthropic, or local models for text and vision tasks. You can also specify model names. The `/api/providers` endpoint returns the current configuration.
 
 ## 4. Uploading Documents
@@ -69,7 +62,7 @@ Download the built-in rule set from `/api/brex-default` to customize validation 
 Check `/api/health` for a status report that includes current provider configuration and timestamp.
 
 ## 14. Security Considerations
-Authentication tokens are signed with `SECRET_KEY` from `.env`. Avoid sending sensitive documents to external providers unless you use the local models. Adjust CORS origins and token expiration values in the settings for better security.
+This simplified setup has no authentication. Avoid exposing it to the public internet.
 
 ## 15. Troubleshooting & Testing
 Run backend tests with `pytest -q` and frontend tests using `yarn test`. Review `test_result.md` for the testing log. If document processing fails, check the backend console output for errors and verify that provider API keys are correct.

--- a/backend/db_sqlite.py
+++ b/backend/db_sqlite.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+from typing import Any, List, Dict
+
+import aiosqlite
+
+DB_PATH = Path(__file__).parent / "aquila.db"
+
+
+class SQLiteDatabase:
+    """Simple async wrapper around SQLite for Aquila."""
+
+    def __init__(self, db_path: Path = DB_PATH):
+        self.db_path = db_path
+        self.conn: aiosqlite.Connection | None = None
+
+    async def connect(self) -> None:
+        self.conn = await aiosqlite.connect(self.db_path)
+        await self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS settings (
+                id INTEGER PRIMARY KEY,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        await self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        await self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS data_modules (
+                dmc TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        await self.conn.commit()
+
+    async def get_settings(self) -> Dict[str, Any] | None:
+        async with self.conn.execute("SELECT data FROM settings WHERE id=1") as cur:
+            row = await cur.fetchone()
+            if row:
+                return json.loads(row[0])
+        return None
+
+    async def save_settings(self, data: Dict[str, Any]) -> None:
+        payload = json.dumps(data)
+        await self.conn.execute(
+            "INSERT OR REPLACE INTO settings(id, data) VALUES(1, ?)",
+            (payload,),
+        )
+        await self.conn.commit()
+
+    async def insert_document(self, doc_id: str, data: Dict[str, Any]) -> None:
+        await self.conn.execute(
+            "INSERT OR REPLACE INTO documents(id, data) VALUES(?, ?)",
+            (doc_id, json.dumps(data)),
+        )
+        await self.conn.commit()
+
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        docs: List[Dict[str, Any]] = []
+        async with self.conn.execute("SELECT data FROM documents") as cur:
+            async for row in cur:
+                docs.append(json.loads(row[0]))
+        return docs
+
+    async def insert_data_module(self, dmc: str, data: Dict[str, Any]) -> None:
+        await self.conn.execute(
+            "INSERT OR REPLACE INTO data_modules(dmc, data) VALUES(?, ?)",
+            (dmc, json.dumps(data)),
+        )
+        await self.conn.commit()
+
+    async def list_data_modules(self) -> List[Dict[str, Any]]:
+        modules: List[Dict[str, Any]] = []
+        async with self.conn.execute("SELECT data FROM data_modules") as cur:
+            async for row in cur:
+                modules.append(json.loads(row[0]))
+        return modules

--- a/backend/websocket_server.py
+++ b/backend/websocket_server.py
@@ -1,0 +1,84 @@
+"""Simplified Aquila backend using SQLite and WebSocket communication."""
+
+import base64
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from .db_sqlite import SQLiteDatabase
+from .models.document import UploadedDocument, DataModule
+from .models.base import DMTypeEnum, SecurityLevel
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Aquila S1000D-AI WS API", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+DB = SQLiteDatabase()
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    await DB.connect()
+    if await DB.get_settings() is None:
+        await DB.save_settings({"brex_rules": {}})
+
+
+class WSMessage(BaseModel):
+    action: str
+    payload: Dict[str, Any] | None = None
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket) -> None:
+    await ws.accept()
+    try:
+        while True:
+            text = await ws.receive_text()
+            try:
+                msg = WSMessage.parse_raw(text)
+            except Exception as exc:  # pragma: no cover - simple validation
+                await ws.send_text(json.dumps({"error": str(exc)}))
+                continue
+            if msg.action == "get_settings":
+                settings = await DB.get_settings()
+                await ws.send_text(json.dumps({"action": "settings", "data": settings}))
+            elif msg.action == "list_documents":
+                docs = await DB.list_documents()
+                await ws.send_text(json.dumps({"action": "documents", "data": docs}))
+            elif msg.action == "upload_document" and msg.payload:
+                content = base64.b64decode(msg.payload.get("content", ""))
+                filename = msg.payload.get("filename", "file.bin")
+                doc = UploadedDocument(
+                    filename=filename,
+                    file_path=str(Path(DB.db_path).parent / filename),
+                    mime_type="application/octet-stream",
+                    file_size=len(content),
+                    sha256_hash="",
+                )
+                await DB.insert_document(doc.id, doc.dict())
+                await ws.send_text(json.dumps({"action": "uploaded", "data": doc.dict()}))
+            elif msg.action == "list_modules":
+                modules = await DB.list_data_modules()
+                await ws.send_text(json.dumps({"action": "modules", "data": modules}))
+            else:
+                await ws.send_text(json.dumps({"error": "unknown action"}))
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/simple_frontend/index.html
+++ b/simple_frontend/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Aquila S1000D-AI Simplified</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        #log { border: 1px solid #ccc; padding: 1rem; height: 200px; overflow: auto; }
+    </style>
+</head>
+<body>
+    <h1>Aquila S1000D-AI (Simplified)</h1>
+    <button id="connect">Connect</button>
+    <button id="getSettings">Get Settings</button>
+    <div id="log"></div>
+    <script>
+        let ws;
+        const log = msg => {
+            const div = document.getElementById('log');
+            div.innerHTML += msg + '<br />';
+            div.scrollTop = div.scrollHeight;
+        };
+        document.getElementById('connect').onclick = () => {
+            ws = new WebSocket('ws://' + location.host + '/ws');
+            ws.onopen = () => log('Connected');
+            ws.onmessage = ev => log('Received: ' + ev.data);
+            ws.onclose = () => log('Disconnected');
+        };
+        document.getElementById('getSettings').onclick = () => {
+            ws && ws.send(JSON.stringify({action: 'get_settings'}));
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a lightweight `backend/websocket_server.py` using SQLite and websockets
- include a small HTML/JS client under `simple_frontend`
- document the simplified setup in README and USER_MANUAL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6874e57dad88832995743ae95396f340